### PR TITLE
Cut release 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "pass-rs"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pass-rs"
-version = "0.3.1"
+version = "0.3.3"
 authors = ["Matt Yaraskavitch <yaraskavitch.matt@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0"


### PR DESCRIPTION
- No changes from 0.3.2 except for pipeline changes.
- 0.3.2 had the wrong version string included as well, resolving.