### PR TITLE
Emit newline by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "pass-rs"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pass-rs"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Matt Yaraskavitch <yaraskavitch.matt@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:alpine3.18 as builder
+FROM rust:alpine3.19 as builder
 
 COPY src/ /build/src/
 COPY Cargo.toml Cargo.lock /build/

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ By default, the password is 38 characters long.
 For a custom length, simply specify a numeric length as an argument.
 
 Options:
+-n             Disable newline when printing password
+-nd            Disable numeric characters
 -nl            Disable lowercase characters
 -nu            Disable uppercase characters
--nd            Disable numeric characters
 -s             Enable special characters in generations (!, @, #, $, etc)
 -h, --help     Print this help dialogue
 ```

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,7 +4,7 @@ pub const DEFAULT_ENABLE_SPECIAL: bool = false;
 pub const DEFAULT_ENABLE_UPPER: bool = true;
 pub const DEFAULT_PASS_LEN: usize = 38;
 pub const DEFAULT_PRINT_HELP: bool = false;
-pub const DEFAULT_ENABLE_NEWLINE: bool = false;
+pub const DEFAULT_DISABLE_NEWLINE: bool = false;
 
 pub const SPECIAL_CHARS: [char; 14] = [
     '!', '#', '$', '%', '&', '*', ']', '[', '(', ')', '{', '}', '+', '-',

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,9 @@ fn main() {
     }
 
     //emit password to user
-    match config.enable_newline {
-        true => println!("{}", pass),
-        false => print!("{}", pass),
+    match config.disable_newline {
+        true => print!("{}", pass),
+        false => println!("{}", pass),
     }
 }
 
@@ -46,7 +46,7 @@ fn print_usage() {
     message += "By default, the password is 38 characters long.\n";
     message += "For a custom length, simply specify a numeric length as an argument.\n\n";
     message += "Options:\n";
-    message += "-n             Enable newline when printing password\n";
+    message += "-n             Disable newline when printing password\n";
     message += "-nd            Disable numeric characters\n";
     message += "-nl            Disable lowercase characters\n";
     message += "-nu            Disable uppercase characters\n";

--- a/src/parseargs.rs
+++ b/src/parseargs.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::constants;
 
 pub struct ConfigArgs {
-    pub enable_newline: bool,
+    pub disable_newline: bool,
     pub enable_digit: bool,
     pub enable_lower: bool,
     pub enable_special: bool,
@@ -16,7 +16,7 @@ pub struct ConfigArgs {
 impl ConfigArgs {
     pub fn new() -> ConfigArgs {
         ConfigArgs {
-            enable_newline: constants::DEFAULT_ENABLE_NEWLINE,
+            disable_newline: constants::DEFAULT_DISABLE_NEWLINE,
             enable_digit: constants::DEFAULT_ENABLE_DIGIT,
             enable_lower: constants::DEFAULT_ENABLE_LOWER,
             enable_special: constants::DEFAULT_ENABLE_SPECIAL,
@@ -30,7 +30,7 @@ impl ConfigArgs {
         for (count, arg) in env::args().enumerate() {
             match arg.as_ref() {
                 "-h" | "--help" => self.print_help = true,
-                "-n" => self.enable_newline = true,
+                "-n" => self.disable_newline = true,
                 "-nd" => self.enable_digit = false,
                 "-nl" => self.enable_lower = false,
                 "-nu" => self.enable_upper = false,


### PR DESCRIPTION
- Change behaviour so that a newline is emitted by default and the `-n` flag must be passed to not emit it. This brings the utility closer in line with CLI tools like `echo`.

- Bumped feature version, as this is a breaking change for a non-1.0 project.

- Closes #10